### PR TITLE
Fixed a small typo in the api documentation

### DIFF
--- a/docs/api/core.getproject.md
+++ b/docs/api/core.getproject.md
@@ -27,7 +27,7 @@ export declare function getProject(id: string, config?: IProjectConfig): IProjec
 
 If @<!-- -->theatre/studio is also loaded, then the state of the project will be managed by the studio.
 
-\[Learn more about exporting\](https://docs.theatrejs.com/in-depth/\#exporting)
+[Learn more about exporting](https://docs.theatrejs.com/in-depth/\#exporting)
 
 ## Example 1
 


### PR DESCRIPTION
The square brackets in a markdown link were escaped (I dared to assumed that by an accident :relaxed: ). 